### PR TITLE
collage_request: edit select tag

### DIFF
--- a/public/page/collere_request/css/style.css
+++ b/public/page/collere_request/css/style.css
@@ -143,3 +143,15 @@ iframe{
     margin-top:10px;
   }
 }
+
+/* 掲載先 */
+form[name='contact'] select{
+  padding:10px;
+  font-size:0.8em;
+}
+form[name="contact"] .flex-column{
+  display:flex;
+  flex-direction:rows;
+  gap:10px;
+}
+

--- a/public/page/collere_request/index.html
+++ b/public/page/collere_request/index.html
@@ -36,29 +36,34 @@
     <div class='item' data-required="true">
       <div class='required'></div>
       <p data-lang='ja'>掲載先</p>
-       <label for="keisaisaki">学外:</label>
-    <select name="keisai" id="keisaisaki">
-        <option value="">--掲載ページを選んで下さい--</option>
-  <option value="技術部">技術部</option>
-  <option value="業務内容">業務内容</option>
-  <option value="技術発表会">技術発表会</option>
-  <option value="リンク">リンク</option>
-  <option value="その他">その他</option>
-　</select> 
-        
-    <label for="keisaisaki">学内:</label>
-    <select name="keisai" id="keisaisaki">
-        <option value="">--掲載ページを選んで下さい--</option>
-  <option value="技術部会">技術部会</option>
-  <option value="調整室">調整室</option>
-  <option value="申請">申請</option>
-  <option value="資料">資料</option>
-　 <option value="各種委員会">各種委員会</option>
-   <option value="講習会実行委員会">講習会実行委員会</option>
-   <option value="専門技術グループ">専門技術グループ</option>
-  <option value="その他">その他</option>
-　</select> 
+      <div class="flex-column">
+        <div>
+          <label for="keisaisaki1">学外:</label>
+          <select name="entry.311241764" id="keisaisaki1">
+            <option value="">--掲載ページを選んで下さい--</option>
+            <option value="技術部">技術部</option>
+            <option value="業務内容">業務内容</option>
+            <option value="技術発表会">技術発表会</option>
+            <option value="リンク">リンク</option>
+            <option value="その他">その他</option>
+          </select> 
+        </div>
+        <div>
+          <label for="keisaisaki2">学内:</label>
+          <select name="entry.1993782594" id="keisaisaki2">
+            <option value="">--掲載ページを選んで下さい--</option>
+            <option value="技術部会">技術部会</option>
+            <option value="調整室">調整室</option>
+            <option value="申請">申請</option>
+            <option value="資料">資料</option>
+            <option value="各種委員会">各種委員会</option>
+            <option value="講習会実行委員会">講習会実行委員会</option>
+            <option value="専門技術グループ">専門技術グループ</option>
+            <option value="その他">その他</option>
+          </select> 
+        </div>
       </div>
+    </div>
 
     <div class='item' data-required="false">
       <div class='required'></div>


### PR DESCRIPTION
今野さん依頼により、学内サイトの掲載依頼ページに、掲載先項目2つ追加の送信不具合に対応しました。
【不具合原因】
・selectタグのname値がGoogleFormの仕様になっていなかった
・元の掲載URL項目が１つだったのに対して、掲載先項目がselectタグ2つになっていた。
【対応】
・GoogleFormの項目を２つ追加
・追加したSelectタグに、GoogleFormのName値を適用
